### PR TITLE
Reference Helm charts by UUID

### DIFF
--- a/bin/edge-sync.js
+++ b/bin/edge-sync.js
@@ -41,12 +41,12 @@ const kubeseal = await new Kubeseal({
 }).init();
 
 const deploy = await new Deployments({
-    fplus, kubeconfig, namespace,
-    cluster: {
-        uuid:       cluster,
-        name:       process.env.CLUSTER_NAME,
+    fplus, kubeconfig, namespace, cluster,
+    values: {
+        cluster:        process.env.CLUSTER_NAME,
+        realm:          process.env.REALM,
+        directory_url:  process.env.DIRECTORY_URL,
     },
-    realm:          process.env.REALM,
 }).init();
 
 nodes.run();

--- a/lib/deployments.js
+++ b/lib/deployments.js
@@ -119,7 +119,7 @@ export class Deployments {
 
     async _init_config () {
         const watcher = await this.fplus.ConfigDB.watcher();
-        const app = Edge.App.SyncConfig;
+        const app = Edge.App.HelmRelease;
 
         /* XXX Also watch our config (app, cluster) and merge onto the
          * global config? */

--- a/lib/deployments.js
+++ b/lib/deployments.js
@@ -83,8 +83,9 @@ class Reconciliation {
         const { response, body } = await this.objs.list(
             this.resource.apiVersion, this.resource.kind, 
             this.deploy.namespace,
-            null, null, null, null,
-            { [LABELS.managed]: LABELS.sync },
+            /*pretty*/null, /*exact*/null, /*exportt*/null,
+            /*fieldSelector*/null,
+            /*labelSelector*/`${LABELS.managed}=${LABELS.sync}`,
         );
         if (response.statusCode != 200)
             throw `Can't list ${this.resource}: ${response.statusCode}`;

--- a/lib/deployments.js
+++ b/lib/deployments.js
@@ -99,17 +99,12 @@ export class Deployments {
         this.cluster = opts.cluster;
         this.kc = opts.kubeconfig;
         this.namespace = opts.namespace;
-
-        this.values = {
-            cluster:    opts.cluster.name,
-            realm:      opts.realm,
-        };
+        this.values = opts.values;
        
         this.log = opts.fplus.debug.log.bind(opts.fplus.debug, "deploy");
     }
 
     async init () {
-
         const config = await this._init_config();
         const deployments = await this._init_deployments();
         this.manifests = this._init_manifests(config, deployments);
@@ -148,19 +143,30 @@ export class Deployments {
     }
 
     async _init_deployments () {
-        const app = Edge.App.Deployments;
+        const { Deployments, HelmChart } = Edge.App;
         const cdb = this.fplus.ConfigDB;
         const watcher = await cdb.watcher();
 
+        /* Take a list of Deployment entry UUIDs. Look up the Deployment
+         * entries (preserving the entry UUID), and then look up and
+         * compile the Helm Chart templates referenced from there.
+         * Returns an array of individual charts which need to be
+         * deployed. */
         const lookup = list => rx.from(list).pipe(
-            rx.mergeMap(agent => cdb.get_config(app, agent)
-                .then(conf => ({ uuid: agent, config: conf }))),
+            rx.mergeMap(agent => cdb.get_config(Deployments, agent)
+                .then(config => ({ uuid: agent, config }))),
+            rx.mergeMap(deployment => rx.from(deployment.config.charts).pipe(
+                rx.mergeMap(ch => cdb.get_config(HelmChart, ch)),
+                /* XXX We could cache (against an etag) to avoid
+                 * recompiling every time... */
+                rx.map(tmpl => template(tmpl)),
+                rx.map(chart => ({ ...deployment, chart })))),
             rx.toArray(),
         );
 
         return watcher
-            .watch_search(app, { cluster: this.cluster.uuid })
-            .pipe(rx.mergeMap(lookup));
+            .watch_search(Deployments, { cluster: this.cluster })
+            .pipe(rx.switchMap(lookup));
     }
 
     _init_manifests (config, deployments) {
@@ -179,17 +185,20 @@ export class Deployments {
 
     create_manifests ({ config, deployments }) {
         return imm.List(deployments)
-            .flatMap(dep => dep.config.charts
-                .map(chart => config.template({
-                    uuid: dep.uuid,
-                    chart: chart,
-                    values: {
-                        ...this.values,
-                        uuid: dep.uuid,
-                        name: dep.config.name,
-                        hostname: dep.config.hostname,
-                    },
-                })))
+            .map(deployment => {
+                const { uuid } = deployment;
+                const chart = deployment.chart({
+                    uuid,
+                    name:       deployment.config.name,
+                    hostname:   deployment.config.hostname,
+                });
+                const values = [this.values, chart.values, deployment.values]
+                    .map(v => v ?? {}).reduce(jmp.merge);
+                return config.template({
+                    uuid, values,
+                    chart:  chart.chart,
+                });
+            })
             .groupBy(Resource);
     }
 

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -5,7 +5,7 @@ export const Edge = {
         HelmChart:      "729fe070-5e67-4bc7-94b5-afd75cb42b03",
         Template:       "72804a19-636b-4836-b62b-7ad1476f2b86",
         Deployments:    "f2b9417a-ef7f-421f-b387-bb8183a48cdb",
-        SyncConfig:     "88436128-09a3-4c9c-b7f4-b0e495137265",
+        HelmRelease:    "88436128-09a3-4c9c-b7f4-b0e495137265",
     },
     Class: {
         Cluster:    "f24d354d-abc1-4e32-98e1-0667b3e40b61",

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -2,6 +2,7 @@ export const Edge = {
     App: {
         Cluster:        "bdb13634-0b3d-4e38-a065-9d88c12ee78d",
         ClusterStatus:  "747a62c9-1b66-4a2e-8dd9-0b70a91b6b75",
+        HelmChart:      "729fe070-5e67-4bc7-94b5-afd75cb42b03",
         Template:       "72804a19-636b-4836-b62b-7ad1476f2b86",
         Deployments:    "f2b9417a-ef7f-421f-b387-bb8183a48cdb",
         SyncConfig:     "88436128-09a3-4c9c-b7f4-b0e495137265",


### PR DESCRIPTION
Instead of referencing deployed charts by name, and assuming we can construct a set of values that will fit any chart, introduce another layer of indirection. Create a Helm Chart object which expands a set of known template values into all the information needed for a HelmRelease, including values. This allows multiple configurations of a single chart to be made available for deployment.