### PR TITLE
Publish 'fieldbus' host taints to the ConfigDB

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -16,9 +16,9 @@ import { Edge }             from "./uuids.js";
 const debug = new Debug();
 
 const LABELS = {
-    host:       "kubernetes.io/hostname",
-    control:    "node-role.kubernetes.io/control-plane",
-    tainted:    "factoryplus.app.amrc.co.uk/specialised",
+    host:           "kubernetes.io/hostname",
+    control:        "node-role.kubernetes.io/control-plane",
+    specialised:    "factoryplus.app.amrc.co.uk/specialised",
 };
 
 export class Nodes {
@@ -48,8 +48,8 @@ export class Nodes {
             value:      obj => {
                 const meta = obj.metadata;
                 const info = obj.status.nodeInfo;
-                const fieldbus = obj.spec.taints
-                    ?.filter(t => t.key == LABELS.tainted)
+                const specialised = obj.spec.taints
+                    ?.filter(t => t.key == LABELS.specialised)
                     ?.map(t => t.value)
                     ?.[0];
                 return {
@@ -57,7 +57,7 @@ export class Nodes {
                     arch:           info.architecture,
                     k8s_version:    info.kubeletVersion,
                     control_plane:  meta.labels[LABELS.control] == "true",
-                    fieldbus,
+                    specialised,
                 };
             },
             equal:      deep_equal,

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -48,8 +48,9 @@ export class Nodes {
                 const meta = obj.metadata;
                 const info = obj.status.nodeInfo;
                 const fieldbus = obj.spec.taints
-                    .filter(t => t.key == "factoryplus.app.amrc.co.uk/fieldbus")
-                    .map(t => t.value)[0];
+                    ?.filter(t => t.key == "factoryplus.app.amrc.co.uk/fieldbus")
+                    ?.map(t => t.value)
+                    ?.[0];
                 return {
                     hostname:       meta.labels[LABELS.host],
                     arch:           info.architecture,

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -18,6 +18,7 @@ const debug = new Debug();
 const LABELS = {
     host:       "kubernetes.io/hostname",
     control:    "node-role.kubernetes.io/control-plane",
+    tainted:    "factoryplus.app.amrc.co.uk/specialised",
 };
 
 export class Nodes {
@@ -48,7 +49,7 @@ export class Nodes {
                 const meta = obj.metadata;
                 const info = obj.status.nodeInfo;
                 const fieldbus = obj.spec.taints
-                    ?.filter(t => t.key == "factoryplus.app.amrc.co.uk/fieldbus")
+                    ?.filter(t => t.key == LABELS.tainted)
                     ?.map(t => t.value)
                     ?.[0];
                 return {

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -47,11 +47,15 @@ export class Nodes {
             value:      obj => {
                 const meta = obj.metadata;
                 const info = obj.status.nodeInfo;
+                const fieldbus = obj.spec.taints
+                    .filter(t => t.key == "factoryplus.app.amrc.co.uk/fieldbus")
+                    .map(t => t.value)[0];
                 return {
                     hostname:       meta.labels[LABELS.host],
                     arch:           info.architecture,
                     k8s_version:    info.kubeletVersion,
                     control_plane:  meta.labels[LABELS.control] == "true",
+                    fieldbus,
                 };
             },
             equal:      deep_equal,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-edge-sync",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Define the taint `factoryplus.app.amrc.co.uk/fieldbus` to indicate 'this host has special/limited hardware and should not be used for running general floating workloads'. The value associated with the taint should be a string identifying the reason for the taint being applied (these are a matter of local policy).

If a host has such a taint, publish it to the ConfigDB. This will allow the Manager to help users select appropriate hosts to deploy Edge Agents to.